### PR TITLE
Allow image snapshotting to take 10mins, not just 5min

### DIFF
--- a/UE4-GCE-Win64-Git-GitHubActions-MSVC.json
+++ b/UE4-GCE-Win64-Git-GitHubActions-MSVC.json
@@ -8,6 +8,7 @@
       "disk_type": "pd-ssd",
       "communicator": "winrm",
       "image_name": "{{user `image_name`}}",
+      "state_timeout": "10m",
       "winrm_username": "packer_user",
       "winrm_insecure": true,
       "winrm_use_ssl": true,


### PR DESCRIPTION
We are occasionally hitting the 5min timeout during vm creation. Bumping to 7min is the suggested solution online. Let's go to 10min so we have some margin there.